### PR TITLE
chore: simplify insecure transport, bump go and alpine

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,3 +1,4 @@
+.git
 *.md
 *.yaml
 *.yml

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,10 @@
+version: 2
+updates:
+  - package-ecosystem: "docker"
+    directory: "/"
+    schedule:
+      interval: "daily"
+  - package-ecosystem: "gomod"
+    directory: "/"
+    schedule:
+      interval: "daily"

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -27,8 +27,5 @@ jobs:
         id: docker_build
         uses: docker/build-push-action@v2
         with:
-          build-args: |
-            GIT_COMMIT=${{ github.sha }}
-            VERSION=${{ steps.tag.outputs.TAG }}
           push: true
           tags: ${{ env.REGISTRY_NAME }}/${{ github.repository }}:${{ steps.tag.outputs.TAG }}

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -1,0 +1,34 @@
+name: main
+
+on:
+  push:
+
+jobs:
+  docker:
+    runs-on: ubuntu-latest
+    env:
+      REGISTRY_NAME: quay.io
+    steps:
+      - uses: actions/checkout@v2
+
+      - name: Login to Docker registry
+        uses: docker/login-action@v1
+        with:
+          registry: ${{ env.REGISTRY_NAME }}
+          username: ${{ github.repository_owner }}
+          password: ${{ secrets.REGISTRY_TOKEN }}
+
+      - name: Choose tag
+        id: tag
+        shell: bash
+        run: echo "::set-output name=TAG::${GITHUB_REF_NAME//\//-}"
+
+      - name: Build and push
+        id: docker_build
+        uses: docker/build-push-action@v2
+        with:
+          build-args: |
+            GIT_COMMIT=${{ github.sha }}
+            VERSION=${{ steps.tag.outputs.TAG }}
+          push: true
+          tags: ${{ env.REGISTRY_NAME }}/${{ github.repository }}:${{ steps.tag.outputs.TAG }}

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -1,0 +1,18 @@
+linters:
+  enable:
+    - gocritic
+    - gosec
+    - gofmt
+    - goimports
+    - gocyclo
+    - goconst
+    - prealloc
+    - revive
+    - unconvert
+    - unparam
+
+linters-settings:
+  gosimple:
+    go: "1.17"
+  gocyclo:
+    min-complexity: 15

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,8 @@
 - Simplify creation of insecure transport;
 - Migrate to go 1.17;
 - Bump alpine version;
-- Add GitHub workflow to automatically publish images.
+- Add GitHub workflow to automatically publish images;
+- Add dependabot alerts.
 
 ## 0.5.0
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,33 +1,39 @@
 # CHANGELOG
 
+## 0.5.1
+
+- Simplify creation of insecure transport;
+- Migrate to go 1.17;
+- Bump alpine version.
+
 ## 0.5.0
 
-* Added support for forwarding bearer token (`/var/run/secrets/kubernetes.io/serviceaccount/token`). It's enabled by default and controlled via `METRP_USE_TOKEN` env;
-* Bugfix: do not forward basic auth credentials to upstreams.
+- Added support for forwarding bearer token (`/var/run/secrets/kubernetes.io/serviceaccount/token`). It's enabled by default and controlled via `METRP_USE_TOKEN` env;
+- Bugfix: do not forward basic auth credentials to upstreams.
 
 ## 0.4.0
 
-* Added support for `METRP_PREFERRED_IPV4` (useful for Downward API).
+- Added support for `METRP_PREFERRED_IPV4` (useful for Downward API).
 
 ## 0.3.0
 
-* Added custom transport to enforce `InsecureSkipVerify: true` (useful for kube-controller-manager).
+- Added custom transport to enforce `InsecureSkipVerify: true` (useful for kube-controller-manager).
 
 ## 0.2.1
 
-* Code refactoring;
-* Now, only GET method is allowed;
-* URLs in metrp.yaml are now validated;
-* Improved README.md.
+- Code refactoring;
+- Now, only GET method is allowed;
+- URLs in metrp.yaml are now validated;
+- Improved README.md.
 
 ## 0.2.0
 
-* Added `METRP_PREFERRED_IPV4_CIDR`, so now it's possible to bind web-servers only to an interface that belongs to a specific prefix, e.g. `192.168.0.0/24`.
+- Added `METRP_PREFERRED_IPV4_CIDR`, so now it's possible to bind web-servers only to an interface that belongs to a specific prefix, e.g. `192.168.0.0/24`.
 
 ## 0.1.1
 
-* Improve error handling.
+- Improve error handling.
 
 ## 0.1.0
 
-* Initial release.
+- Initial release.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,8 @@
 
 - Simplify creation of insecure transport;
 - Migrate to go 1.17;
-- Bump alpine version.
+- Bump alpine version;
+- Add GitHub workflow to automatically publish images.
 
 ## 0.5.0
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,9 +1,4 @@
-ARG ALPINE_VERSION=3.15.0
-ARG GOLANG_VERSION=1.17.7-alpine3.15
-ARG VERSION
-ARG GIT_COMMIT
-
-FROM golang:${GOLANG_VERSION} as builder
+FROM golang:1.17.7-alpine3.15 as builder
 
 WORKDIR /go/src/metrp/
 COPY go.mod go.sum ./
@@ -16,7 +11,7 @@ RUN go install \
     -installsuffix "static" \
     ./...
 
-FROM alpine:${ALPINE_VERSION} as runtime
+FROM alpine:3.15.0 as runtime
 
 RUN set -x \
   && apk add --update --no-cache ca-certificates tzdata \

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,9 +1,9 @@
-ARG ALPINE_VERSION=3.13.5
-ARG GOLANG_VERSION=1.16.4-alpine3.13
+ARG ALPINE_VERSION=3.15.0
+ARG GOLANG_VERSION=1.17.7-alpine3.15
+ARG VERSION
+ARG GIT_COMMIT
 
 FROM golang:${GOLANG_VERSION} as builder
-
-ARG VERSION
 
 WORKDIR /go/src/metrp/
 COPY go.mod go.sum ./
@@ -14,12 +14,6 @@ ENV CGO_ENABLED=0
 
 RUN go install \
     -installsuffix "static" \
-    -ldflags "                                          \
-      -X main.Version=${VERSION}                        \
-      -X main.GoVersion=$(go version | cut -d " " -f 3) \
-      -X main.Compiler=$(go env CC)                     \
-      -X main.Platform=$(go env GOOS)/$(go env GOARCH) \
-    " \
     ./...
 
 FROM alpine:${ALPINE_VERSION} as runtime

--- a/README.md
+++ b/README.md
@@ -33,6 +33,10 @@ Minuses:
 
 The same thing could be done using a reverse-proxy such as `caddy`, `nginx`, or others, though they seem to be a bit heavy for the task and more difficult to configure.
 
+## Installation
+
+Docker images are published on [quay.io/weisdd/metrp](https://quay.io/repository/weisdd/metrp?tab=tags).
+
 ## Configuration
 
 ### Environment variables

--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -1,41 +1,9 @@
 version: '3'
 
-env:
-  TARGET: ./...
-
 tasks:
   default:
-    - task: test
     - task: lint
 
-  test:
-    cmds:
-      - go test $TARGET
-
   lint:
-    deps:
-      - lint:go-vet
-      - lint:golint
-      - lint:golangci-lint
-      - lint:gosec
-      - lint:staticcheck
-
-  lint:go-vet:
     cmds:
-      - go vet $TARGET
-
-  lint:golint:
-    cmds:
-      - golint $TARGET
-
-  lint:golangci-lint:
-    cmds:
-      - golangci-lint run $TARGET
-
-  lint:gosec:
-    cmds:
-      - gosec -quiet $TARGET
-
-  lint:staticcheck:
-    cmds:
-      - staticcheck $TARGET
+      - golangci-lint run

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/weisdd/metrp
 
-go 1.16
+go 1.17
 
 require (
 	github.com/caarlos0/env/v6 v6.5.0


### PR DESCRIPTION
- Simplify creation of insecure transport;
- Migrate to go 1.17;
- Bump alpine version;
- Add GitHub workflow to automatically publish images;
- Add dependabot alerts.