### PR TITLE
Feature/go 1.18

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -20,6 +20,9 @@ jobs:
 
       - name: golangci-lint
         uses: golangci/golangci-lint-action@v3
+        # TODO: remove once the action starts downloading v1.45.0+
+        with:
+          version: v1.45.0
 
   docker:
     runs-on: ubuntu-latest

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -16,7 +16,7 @@ jobs:
 
       - uses: actions/setup-go@v2
         with:
-          go-version: "1.17"
+          go-version: "1.18"
 
       - name: golangci-lint
         uses: golangci/golangci-lint-action@v3

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -13,6 +13,6 @@ linters:
 
 linters-settings:
   gosimple:
-    go: "1.17"
+    go: "1.18"
   gocyclo:
     min-complexity: 15

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # CHANGELOG
 
+## 0.5.2
+
+- Add graceful shutdown;
+- Migrate to go 1.18 (including `net/netip`).
+
 ## 0.5.1
 
 - Simplify creation of insecure transport;

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## 0.5.2
 
 - Add graceful shutdown;
+- Bump alpine to 3.15.1;
 - Migrate to go 1.18 (including `net/netip`).
 
 ## 0.5.1

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.17.7-alpine3.15 as builder
+FROM golang:1.18.0-alpine3.15 as builder
 
 WORKDIR /go/src/metrp/
 COPY go.mod go.sum ./

--- a/Dockerfile
+++ b/Dockerfile
@@ -11,7 +11,7 @@ RUN go install \
     -installsuffix "static" \
     ./...
 
-FROM alpine:3.15.0 as runtime
+FROM alpine:3.15.1 as runtime
 
 RUN set -x \
   && apk add --update --no-cache ca-certificates tzdata \

--- a/README.md
+++ b/README.md
@@ -52,6 +52,7 @@ Docker images are published on [ghcr.io/weisdd/metrp](https://github.com/weisdd/
 | `METRP_PASSWORD`            |               | Password to require if basic authentication is enabled.      |
 | `METRP_USE_TOKEN` | `true` | Whether to forward k8s token to upstream (useful for `kube-apiserver` and other upstreams that require authorization). Be careful though with untrusted upstreams! |
 | `METRP_READ_TIMEOUT`        | `10s`         | `ReadTimeout` covers the time from when the connection is accepted to when the request body is fully read (if you do read the body, otherwise to the end of the headers). [More details](https://blog.cloudflare.com/the-complete-guide-to-golang-net-http-timeouts/) |
+| `METRP_SHUTDOWN_TIMEOUT` | `20s` | Maximum amount of time to wait for all connections to be closed. [More details](https://pkg.go.dev/net/http#Server.Shutdown) |
 | `METRP_WRITE_TIMEOUT`       | `10s`           | `WriteTimeout` normally covers the time from the end of the request header read to the end of the response write (a.k.a. the lifetime of the ServeHTTP). [More details](https://blog.cloudflare.com/the-complete-guide-to-golang-net-http-timeouts/) |
 
 ### metrp.yaml syntax

--- a/cmd/metrp/server.go
+++ b/cmd/metrp/server.go
@@ -1,0 +1,60 @@
+package main
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"net/http"
+	"os"
+	"os/signal"
+	"syscall"
+	"time"
+)
+
+// serve starts a web server and ensures graceful shutdown
+func (app *application) serve() error {
+	srv := &http.Server{
+		Addr:         fmt.Sprintf("%s:%d", app.IP, app.Port),
+		ErrorLog:     app.errorLog,
+		Handler:      app.routes(),
+		IdleTimeout:  time.Minute,
+		ReadTimeout:  app.ReadTimeout,
+		WriteTimeout: app.WriteTimeout,
+	}
+
+	shutdownError := make(chan error)
+
+	go func() {
+		quit := make(chan os.Signal, 1)
+		signal.Notify(quit, syscall.SIGINT, syscall.SIGTERM)
+		s := <-quit
+
+		app.infoLog.Printf("Caught %s signal, waiting for all connections to be closed within %s", s, app.GracefulShutdownTimeout)
+
+		ctx, cancel := context.WithTimeout(context.Background(), app.GracefulShutdownTimeout)
+		defer cancel()
+
+		err := srv.Shutdown(ctx)
+		if err != nil {
+			shutdownError <- err
+		}
+
+		shutdownError <- nil
+	}()
+
+	app.infoLog.Printf("starting server on %s:%d", app.IP, app.Port)
+
+	err := srv.ListenAndServe()
+	if !errors.Is(err, http.ErrServerClosed) {
+		return err
+	}
+
+	err = <-shutdownError
+	if err != nil {
+		return err
+	}
+
+	app.infoLog.Printf("Successfully stopped server")
+
+	return nil
+}

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/weisdd/metrp
 
-go 1.17
+go 1.18
 
 require (
 	github.com/caarlos0/env/v6 v6.9.1


### PR DESCRIPTION
- Add graceful shutdown;
- Bump alpine to 3.15.1;
- Migrate to go 1.18 (including `net/netip`).